### PR TITLE
Allow kwargs in decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ from japaneseverbconjugator.src import JapaneseVerbFormGenerator as japaneseVerb
 from japaneseverbconjugator.src.constants.EnumeratedTypes import VerbClass, Tense, Polarity
 
 jvfg = japaneseVerbFormGenerator.JapaneseVerbFormGenerator() # creates JapaneseVerbFormGenerator instance
-jvfg.generate_plain_form("飲む", VerbClass.GODAN, Tense.NONPAST, Polarity.POSTIIVE) # returns '飲む'
+jvfg.generate_plain_form("飲む", VerbClass.GODAN, Tense.NONPAST, Polarity.POSITIVE) # returns '飲む'
 jvfg.generate_plain_form("飲む", VerbClass.GODAN, Tense.NONPAST, Polarity.NEGATIVE) # returns '飲まない'
 ```
 

--- a/src/Decorators.py
+++ b/src/Decorators.py
@@ -34,7 +34,6 @@ def containsJapaneseCharacters(verb):
 def validateJapaneseVerbDecorator(func):
     def wrapper(self, verb, *args):
         if len(verb) < 2:
-            print("here")
             raise Exception("Invalid Japanese Verb Length", len(verb), verb)
 
         if verb[-1:] not in [U_PARTICLE, KU_PARTICLE, GU_PARTICLE, SU_PARTICLE, TSU_PARTICLE, NU_PARTICLE, BU_PARTICLE, MU_PARTICLE, RU_PARTICLE]:

--- a/src/Decorators.py
+++ b/src/Decorators.py
@@ -32,7 +32,7 @@ def containsJapaneseCharacters(verb):
     return True
 
 def validateJapaneseVerbDecorator(func):
-    def wrapper(self, verb, *args):
+    def wrapper(self, verb, *args, **kwargs):
         if len(verb) < 2:
             raise Exception("Invalid Japanese Verb Length", len(verb), verb)
 
@@ -42,7 +42,7 @@ def validateJapaneseVerbDecorator(func):
         if not containsJapaneseCharacters(verb):
             raise Exception("Non-Japanese Character Found", verb)
 
-        # assuming *args will always have the correct arguments because initial function call succeeded
-        return func(self, verb, *args)
+        # assuming *args and **kwargs will always have the correct arguments because initial function call succeeded
+        return func(self, verb, *args, **kwargs)
     return wrapper
     


### PR DESCRIPTION
- changed `validateJapaneseVerbDecorator` to allow for any keyword arguments
- removed a print statement probably meant for debug purposes
- fixed a typo in readme code